### PR TITLE
Use HTTPS for Gavatar

### DIFF
--- a/src/Estina/Bundle/HomeBundle/Resources/views/Pages/faq.html.twig
+++ b/src/Estina/Bundle/HomeBundle/Resources/views/Pages/faq.html.twig
@@ -166,7 +166,7 @@ užkandžių.
 
 <h2 id="kaip-ikelti-nuotrauka">Kaip įkelti savo nuotrauką prie pranešimo?</h2>
 <p>
-Pranešėjų nuotraukos imamos iš <a href="http://www.gravatar.com/">Gravatar</a>
+Pranešėjų nuotraukos imamos iš <a href="https://www.gravatar.com/">Gravatar</a>
 svetainės. Nuotrauka atpažįstama pagal el. pašto adresą, kurį įvedėte
 registruodami pranešimą. Jei dalyvis nėra užsiregistravęs minėtoje svetainėje,
 pagal tą patį el. pašto adresą sugeneruojamas mielas robotas iš

--- a/src/Estina/Bundle/HomeBundle/Twig/GravatarExtension.php
+++ b/src/Estina/Bundle/HomeBundle/Twig/GravatarExtension.php
@@ -26,7 +26,7 @@ class GravatarExtension extends \Twig_Extension
     {
 
         $defaultImage = 'https://robohash.org/' . $this->hashEmail($email) . '.png?size=' . sprintf('%sx%s', $size, $size);
-        return  $grav_url = "http://www.gravatar.com/avatar/" . $this->hashEmail($email)
+        return  $grav_url = "https://www.gravatar.com/avatar/" . $this->hashEmail($email)
             . "?s=" . $size . '&r=' . $rating . "&d=" . $defaultImage;
     }
 

--- a/web/assets/vendor/bootflat/talk.html
+++ b/web/assets/vendor/bootflat/talk.html
@@ -96,7 +96,7 @@
                             <div class="col-md-3">
                                 <div class="">
                                     <p class="text-center">
-                                        <img src="http://www.gravatar.com/avatar/128ecf542a35ac5270a87dc740918404?s=150&r=G&d=https://robohash.org/128ecf542a35ac5270a87dc740918404.png?size=150x150" alt="" class="media-object img-rounded talk-img">
+                                        <img src="https://www.gravatar.com/avatar/128ecf542a35ac5270a87dc740918404?s=150&r=G&d=https://robohash.org/128ecf542a35ac5270a87dc740918404.png?size=150x150" alt="" class="media-object img-rounded talk-img">
                                     </p>
                                     <p class="text-center">
                                         Žilvinas


### PR DESCRIPTION
So browsers (e.g. Firefox) would not block not secure content in HTTPS site (https://2018.notrollsallowed.com)

**Before fix:**
![nta-no-https](https://user-images.githubusercontent.com/1453957/42708648-939131f2-86e6-11e8-96b7-a0a5d5791a4f.jpeg)
**After fix:**
![nta-with-https](https://user-images.githubusercontent.com/1453957/42708663-9e6b2ff6-86e6-11e8-985b-dea5368141bc.jpeg)
